### PR TITLE
Tier List Fix

### DIFF
--- a/_posts/2023-18-08-motherboads-list.md
+++ b/_posts/2023-18-08-motherboads-list.md
@@ -328,7 +328,7 @@ authors: [logitg]
 > Precio sugerido: Max 100 Dolares
 {: .prompt-tip}
 
->Maximo recomendado: i5 13400 / i5 12600K
+>Maximo recomendado: Ryzen 5 5600X / 4650G / 3600XT
 {: .prompt-info }
 
 - Asrock A520M HVS


### PR DESCRIPTION
Encontré un error en la Tier List, en el sector Tier D de las Motherboards AM4 Lo corregí con la info de la versión de Google Docs/YGA